### PR TITLE
feat(upload): Busboy's folder should not be the same as your drive

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -8,8 +8,7 @@ const app = express();
 
 bb.extend(app, {
     upload: true,
-    path: '/tmp/drive',
-    allowedPath: /./
+    allowedPath: /^\/api\/drive.*/
 });
 
 app.use(function (req, res, next) {


### PR DESCRIPTION
- allow to handle upload files only on /api/drive
- the busboy's **path** config is its working tmp folder, it shouldn't be the same as your drive folder